### PR TITLE
feat: migrate to api.cloudflare.com

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -182,19 +182,19 @@ When the context changes, the entire cache is **cleared before re-fetching** all
 
 ### Configuration options
 
-| Option          | Type          | Default                               | Description                                           |
-| --------------- | ------------- | ------------------------------------- | ----------------------------------------------------- |
-| `appId`         | `string`      | —                                     | Flagship app ID (mutually exclusive with `endpoint`)  |
-| `accountId`     | `string`      | —                                     | Account ID (required with `appId`)                    |
-| `baseUrl`       | `string`      | `https://api.flagship.cloudflare.dev` | Base URL override (only used with `appId`)            |
-| `endpoint`      | `string`      | —                                     | Full evaluation URL (mutually exclusive with `appId`) |
-| `authToken`     | `string`      | —                                     | Bearer token — adds `Authorization: Bearer` header    |
-| `logging`       | `boolean`     | `false`                               | Log fetch errors and cache misses to the console      |
-| `prefetchFlags` | `string[]`    | `[]`                                  | Flag keys to fetch on init and every context change   |
-| `timeout`       | `number`      | `5000`                                | Request timeout in ms                                 |
-| `retries`       | `number`      | `1`                                   | Retry attempts (max 10)                               |
-| `retryDelay`    | `number`      | `1000`                                | Delay between retries in ms (max 30 000)              |
-| `fetchOptions`  | `RequestInit` | `{}`                                  | Custom fetch options (headers, credentials, etc.)     |
+| Option          | Type          | Default                      | Description                                           |
+| --------------- | ------------- | ---------------------------- | ----------------------------------------------------- |
+| `appId`         | `string`      | —                            | Flagship app ID (mutually exclusive with `endpoint`)  |
+| `accountId`     | `string`      | —                            | Account ID (required with `appId`)                    |
+| `baseUrl`       | `string`      | `https://api.cloudflare.com` | Base URL override (only used with `appId`)            |
+| `endpoint`      | `string`      | —                            | Full evaluation URL (mutually exclusive with `appId`) |
+| `authToken`     | `string`      | —                            | Bearer token — adds `Authorization: Bearer` header    |
+| `logging`       | `boolean`     | `false`                      | Log fetch errors and cache misses to the console      |
+| `prefetchFlags` | `string[]`    | `[]`                         | Flag keys to fetch on init and every context change   |
+| `timeout`       | `number`      | `5000`                       | Request timeout in ms                                 |
+| `retries`       | `number`      | `1`                          | Retry attempts (max 10)                               |
+| `retryDelay`    | `number`      | `1000`                       | Delay between retries in ms (max 30 000)              |
+| `fetchOptions`  | `RequestInit` | `{}`                         | Custom fetch options (headers, credentials, etc.)     |
 
 ## Evaluation context
 

--- a/packages/flagship/src/client.ts
+++ b/packages/flagship/src/client.ts
@@ -174,7 +174,7 @@ function resolveEndpoint(options: FlagshipProviderOptions): string {
 	}
 
 	const base = (baseUrl || FLAGSHIP_DEFAULT_BASE_URL).replace(/\/+$/, '');
-	const resolved = `${base}/v1/${encodeURIComponent(accountId)}/apps/${encodeURIComponent(appId!)}/evaluate`;
+	const resolved = `${base}/client/v4/accounts/${encodeURIComponent(accountId)}/flagship/apps/${encodeURIComponent(appId!)}/evaluate`;
 
 	try {
 		new URL(resolved);

--- a/packages/flagship/src/types.ts
+++ b/packages/flagship/src/types.ts
@@ -1,5 +1,5 @@
 /** Default base URL for the Flagship API. */
-export const FLAGSHIP_DEFAULT_BASE_URL = 'https://api.flagship.cloudflare.dev';
+export const FLAGSHIP_DEFAULT_BASE_URL = 'https://api.cloudflare.com';
 
 /**
  * Configuration options for Flagship providers.
@@ -24,7 +24,7 @@ export interface FlagshipProviderOptions {
 
 	/**
 	 * Base URL for the Flagship API. Only used with `appId`.
-	 * @default 'https://api.flagship.cloudflare.dev'
+	 * @default 'https://api.cloudflare.com'
 	 */
 	baseUrl?: string;
 

--- a/packages/flagship/tests/client.test.ts
+++ b/packages/flagship/tests/client.test.ts
@@ -464,7 +464,7 @@ describe('FlagshipClient', () => {
 			await client.evaluate('my-flag', {});
 
 			const calledUrl: string = (global.fetch as any).mock.calls[0][0];
-			expect(calledUrl).toContain('flagship.cloudflare.dev');
+			expect(calledUrl).toContain('api.cloudflare.com');
 			expect(calledUrl).toContain('acct-1');
 			expect(calledUrl).toContain('app-1');
 		});
@@ -479,7 +479,8 @@ describe('FlagshipClient', () => {
 			await client.evaluate('my-flag', {});
 
 			const calledUrl: string = (global.fetch as any).mock.calls[0][0];
-			expect(calledUrl).not.toContain('//v1');
+			expect(calledUrl).not.toContain('//client');
+			expect(calledUrl).toContain('/client/v4/accounts/acct-1/flagship/apps/app-1/evaluate');
 		});
 
 		it('encodes special characters in appId and accountId', async () => {


### PR DESCRIPTION
Updates the default base URL constant, JSdoc, test assertion, and API reference doc to `api.cloudflare.com`