### PR TITLE
ci(pull-request): declare permissions on the PR pipeline

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   format:
     name: Format
@@ -101,6 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [format, lint, typecheck, test]
+    permissions:
+      contents: read
+      pull-requests: write   # pkg-pr-new comments on the PR with the preview URL
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Adds an explicit token scope to `pull-request.yml`:

- Top-level: `contents: read` — applies to all 5 read-only jobs (format / lint / build / typecheck / test).
- `preview` job override: `contents: read` + `pull-requests: write`. The job ends with `pnpm dlx pkg-pr-new publish ./packages/*`, which posts a comment on the PR with the preview install URL, so `pull-requests: write` is the documented minimum for that action.

Lines up with the per-job permissions blocks already in `release.yml` and `bonk.yml`. YAML validated with `yaml.safe_load`.