### PR TITLE
fix: harden release automation

### DIFF
--- a/.changeset/monorepo-restructure.md
+++ b/.changeset/monorepo-restructure.md
@@ -3,5 +3,3 @@
 ---
 
 Restructure repository as a multi-language SDK monorepo under `packages/<language>/`. No API changes.
-
-Upgrade root devDependencies: `lint-staged` 16→17, `@changesets/changelog-github` 0.6→0.7, `oxfmt` 0.43→0.49, `pkg-pr-new` 0.0.66→0.0.71.

--- a/.github/changeset-version.ts
+++ b/.github/changeset-version.ts
@@ -18,6 +18,12 @@ type WorkspacePackage = {
 	isSdk: boolean;
 };
 
+type PnpmListPackage = {
+	name?: string;
+	version?: string;
+	path?: string;
+};
+
 type ChangesetEntry = {
 	name: string;
 	bump: 'major' | 'minor' | 'patch' | 'none';
@@ -25,7 +31,6 @@ type ChangesetEntry = {
 
 const root = process.cwd();
 const changesetDirectory = join(root, '.changeset');
-const ignoredDirectories = new Set(['.git', '.husky', 'node_modules', 'dist', 'coverage', '.wrangler']);
 const bumpOrder = new Map<ChangesetEntry['bump'], number>([
 	['none', 0],
 	['patch', 1],
@@ -39,37 +44,39 @@ function readJson(path: string): PackageJson {
 	return JSON.parse(readFileSync(path, 'utf8')) as PackageJson;
 }
 
-function isSdkDirectory(directory: string): boolean {
-	const parts = relative(root, directory).split('/');
-	return parts[0] === 'packages' && parts.length === 2;
-}
+function readWorkspacePackages(): WorkspacePackage[] {
+	const output = execSync('pnpm list --recursive --depth -1 --json', { encoding: 'utf8' });
+	let packages: PnpmListPackage[];
 
-function readWorkspacePackages(directory = root): WorkspacePackage[] {
-	const packageJsonPath = join(directory, 'package.json');
-	const packages: WorkspacePackage[] = [];
-
-	if (directory !== root && existsSync(packageJsonPath)) {
-		const packageJson = readJson(packageJsonPath);
-
-		if (packageJson.name !== undefined && packageJson.version !== undefined) {
-			packages.push({
-				name: packageJson.name,
-				directory,
-				version: packageJson.version,
-				isSdk: isSdkDirectory(directory),
-			});
-		}
+	try {
+		packages = JSON.parse(output) as PnpmListPackage[];
+	} catch (cause) {
+		throw new Error('Could not parse pnpm workspace package list. Run `pnpm list --recursive --depth -1 --json` to inspect the output.', {
+			cause,
+		});
 	}
 
-	for (const entry of readdirSync(directory, { withFileTypes: true })) {
-		if (!entry.isDirectory() || ignoredDirectories.has(entry.name)) {
-			continue;
+	return packages.flatMap((packageInfo) => {
+		if (
+			packageInfo.path === undefined ||
+			packageInfo.path === root ||
+			packageInfo.name === undefined ||
+			packageInfo.version === undefined
+		) {
+			return [];
 		}
 
-		packages.push(...readWorkspacePackages(join(directory, entry.name)));
-	}
+		const packageJson = readJson(join(packageInfo.path, 'package.json'));
 
-	return packages;
+		return [
+			{
+				name: packageInfo.name,
+				directory: packageInfo.path,
+				version: packageInfo.version,
+				isSdk: packageJson.flagship?.language !== undefined,
+			},
+		];
+	});
 }
 
 function readSdkPackages(): WorkspacePackage[] {
@@ -78,7 +85,8 @@ function readSdkPackages(): WorkspacePackage[] {
 
 function parseChangesetEntries(frontmatter: string): ChangesetEntry[] {
 	return frontmatter
-		.split('\n')
+		.split(/\r?\n/)
+		.map((line) => line.replace(/\s+#.*$/, ''))
 		.map((line) => /^['"]?([^'":]+)['"]?\s*:\s*(major|minor|patch|none)\s*$/.exec(line.trim()))
 		.filter((match): match is RegExpExecArray => match !== null)
 		.map((match) => ({ name: match[1], bump: match[2] as ChangesetEntry['bump'] }));
@@ -98,13 +106,27 @@ function readChangesetFiles(): string[] {
 
 function parseChangeset(file: string): { entries: ChangesetEntry[]; frontmatter: string; body: string } | undefined {
 	const content = readFileSync(file, 'utf8');
-	const match = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/.exec(content);
+	const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(content);
 
 	if (match === null) {
 		return undefined;
 	}
 
 	return { entries: parseChangesetEntries(match[1]), frontmatter: match[1], body: match[2] };
+}
+
+function replaceFirstVersionLine(content: string, targetVersion: string): { content: string; previousVersion: string } | undefined {
+	const versionLinePattern = /^(\s*version\s*=\s*")([^"]+)(")/m;
+	const match = versionLinePattern.exec(content);
+
+	if (match === null) {
+		return undefined;
+	}
+
+	return {
+		content: `${content.slice(0, match.index)}${match[1]}${targetVersion}${match[3]}${content.slice(match.index + match[0].length)}`,
+		previousVersion: match[2],
+	};
 }
 
 export function validatePendingChangesets(): void {
@@ -136,12 +158,6 @@ export function validatePendingChangesets(): void {
 		}
 
 		const sdkEntries = parsed.entries.filter((entry) => sdkPackageNameSet.has(entry.name));
-		const touchesSdk = sdkEntries.length > 0;
-
-		if (!touchesSdk) {
-			errors.push(`Changeset ${relative(root, file)} does not bump any SDK package. Every release changeset must target at least one SDK.`);
-		}
-
 		const noneSDKNames = sdkEntries.filter((entry) => entry.bump === 'none').map((entry) => entry.name);
 
 		if (noneSDKNames.length > 0) {
@@ -214,25 +230,22 @@ export function syncNativeManifests(): void {
 			}
 
 			const original = readFileSync(manifestPath, 'utf8');
-			const versionLinePattern = /^(\s*version\s*=\s*")([^"]+)(")/gm;
-			const firstMatch = versionLinePattern.exec(original);
+			const updated = replaceFirstVersionLine(original, targetVersion);
 
-			if (firstMatch === null) {
+			if (updated === undefined) {
 				errors.push(
 					`Could not find a top-level 'version = "..."' line in ${relative(root, manifestPath)}. Add one so release automation can sync it.`,
 				);
 				continue;
 			}
 
-			if (firstMatch[2] === targetVersion) {
+			if (updated.previousVersion === targetVersion) {
 				console.log(`${relative(root, manifestPath)} already at ${targetVersion}.`);
 				continue;
 			}
 
-			const previousVersion = firstMatch[2];
-			const updated = original.replace(versionLinePattern, `$1${targetVersion}$3`);
-			writeFileSync(manifestPath, updated);
-			console.log(`Synced ${relative(root, manifestPath)} ${previousVersion} -> ${targetVersion}.`);
+			writeFileSync(manifestPath, updated.content);
+			console.log(`Synced ${relative(root, manifestPath)} ${updated.previousVersion} -> ${targetVersion}.`);
 		}
 
 		for (const manifest of tagOnlyManifestFiles) {
@@ -255,10 +268,21 @@ export function syncNativeManifests(): void {
 
 function runRelease(): void {
 	validatePendingChangesets();
-	expandChangesetsToAllSdks();
-	execSync('pnpm changeset version', {
-		stdio: 'inherit',
-	});
+	const changesetSnapshot = new Map(readChangesetFiles().map((file) => [file, readFileSync(file, 'utf8')]));
+
+	try {
+		expandChangesetsToAllSdks();
+		execSync('pnpm changeset version', {
+			stdio: 'inherit',
+		});
+	} catch (error) {
+		for (const [file, content] of changesetSnapshot) {
+			writeFileSync(file, content);
+		}
+
+		throw error;
+	}
+
 	syncNativeManifests();
 	execSync('pnpm install --no-frozen-lockfile', {
 		stdio: 'inherit',

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,9 @@ name: Pull Request
 on:
   pull_request:
     paths-ignore:
+      - 'docs/**'
       - '*.md'
+      - '.changeset/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -131,4 +133,4 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - run: pnpm dlx pkg-pr-new publish './packages/typescript'
+      - run: pnpm dlx pkg-pr-new publish './packages/*'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,11 +117,11 @@ Pick only the SDK package(s) you actually changed. The release workflow expands 
 
 The release pipeline runs `.github/changeset-version.ts`, which:
 
-1. Validates every pending changeset — fails fast on unknown packages, non-SDK-only changesets, or SDK entries with a `none` bump.
+1. Validates every pending changeset — fails fast on unknown packages or SDK entries with a `none` bump.
 2. Expands the changeset to include every SDK package so they share the bump.
 3. Runs `pnpm changeset version`, producing one PR titled `chore(release): version SDK packages` with all SDK `package.json` and `CHANGELOG.md` updates.
 4. Syncs the new version into native manifests beside each SDK:
-   - `pyproject.toml` / `Cargo.toml` — all `version = "..."` lines in the file are updated in-place. The manifest must contain at least one such line or the release fails.
+   - `pyproject.toml` / `Cargo.toml` — the first package `version = "..."` line in the file is updated in-place. The manifest must contain at least one such line or the release fails.
    - `go.mod` — no file sync. Go modules are versioned exclusively via git tags; the script logs this and moves on.
 5. Re-runs `pnpm install` to refresh the lockfile.
 
@@ -130,15 +130,15 @@ After merge the same workflow runs `pnpm changeset publish` and:
 - Publishes public npm SDKs (currently `@cloudflare/flagship`).
 - Skips npm publish for `private: true` SDKs but still creates a git tag (`privatePackages.tag: true`). Language-specific publish workflows (PyPI, crates.io, etc.) should subscribe to those tags. For Go, the git tag is the version — no additional file sync is needed.
 
-Every releasable SDK must have a `package.json` so Changesets can discover and version it, even if the actual package is published to PyPI, crates.io, Go modules, or another registry. Non-npm SDK packages should use `private: true` plus `flagship.language` and keep their native manifest beside it:
+Every releasable SDK must have a `package.json` so Changesets can discover and version it, even if the actual package is published to PyPI, crates.io, Go modules, or another registry. Release automation treats workspace packages with `flagship.language` as SDKs. Non-npm SDK packages should use `private: true` plus `flagship.language` and keep their native manifest beside it:
 
-| Language | Native manifest  | Version sync                                          |
-| -------- | ---------------- | ----------------------------------------------------- |
-| Python   | `pyproject.toml` | All `version = "..."` lines updated by release script |
-| Rust     | `Cargo.toml`     | All `version = "..."` lines updated by release script |
-| Go       | `go.mod`         | No file sync — version is the git tag only            |
+| Language | Native manifest  | Version sync                                                   |
+| -------- | ---------------- | -------------------------------------------------------------- |
+| Python   | `pyproject.toml` | First package `version = "..."` line updated by release script |
+| Rust     | `Cargo.toml`     | First package `version = "..."` line updated by release script |
+| Go       | `go.mod`         | No file sync — version is the git tag only                     |
 
-PR CI runs `pnpm run changeset:validate` (the `Changesets` job) so malformed, non-SDK, or `none`-bumped SDK changesets fail before merge.
+PR CI runs `pnpm run changeset:validate` (the `Changesets` job) so malformed changesets and `none`-bumped SDK changesets fail before merge.
 
 Changesets should remain the only release intent file. Do not add release-please, semantic-release, or language-specific release manifests unless the release workflow is explicitly changed to derive them from Changesets.
 


### PR DESCRIPTION
## Summary
- Discover SDK packages via pnpm workspace metadata and `flagship.language` instead of directory shape.
- Make changeset parsing and native manifest version sync more precise and resilient.
- Update PR packaging/docs to match multi-language package publishing behavior.

## Tests
- pnpm run check