### PR TITLE
fix: pypi publish pipeline and workflows

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"ignore": [],
-	"privatePackages": { "version": true, "tag": true },
+	"privatePackages": { "version": true, "tag": false },
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true
 	}

--- a/.changeset/vast-kids-wait.md
+++ b/.changeset/vast-kids-wait.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/flagship": patch
+---
+
+Fix release pipeline: Python checks on push to main, suppress private SDK changelogs, fix PyPI publish trigger.

--- a/.changeset/vast-kids-wait.md
+++ b/.changeset/vast-kids-wait.md
@@ -2,4 +2,4 @@
 "@cloudflare/flagship": patch
 ---
 
-Fix release pipeline: Python checks on push to main, suppress private SDK changelogs, fix PyPI publish trigger.
+Fix release pipeline: Python checks on push to main, canonical single-package release notes, no private SDK tags, and reliable PyPI publish trigger.

--- a/.github/changeset-version.ts
+++ b/.github/changeset-version.ts
@@ -10,7 +10,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import readChangesets from '@changesets/read';
 import type { NewChangeset, Release, VersionType } from '@changesets/types';
@@ -159,6 +159,21 @@ function patchTomlField<T>(manifestPath: string, targetVersion: string, errors: 
 	console.log(`Synced ${relativePath} -> ${targetVersion}.`);
 }
 
+/**
+ * Changesets generates a CHANGELOG.md for every versioned package, including private ones.
+ * Private SDK changelogs are duplicates of the TypeScript SDK changelog — delete them so
+ * they don't appear in the release PR diff or clutter the repository.
+ */
+function deletePrivateSdkChangelogs(): void {
+	for (const pkg of readSdkPackages()) {
+		if (pkg.packageJson.private !== true) continue;
+		const changelog = join(pkg.dir, 'CHANGELOG.md');
+		if (!existsSync(changelog)) continue;
+		rmSync(changelog);
+		console.log(`Deleted ${relative(ROOT, changelog)} (private SDK — changelog not needed).`);
+	}
+}
+
 async function runRelease(): Promise<void> {
 	await validatePendingChangesets();
 
@@ -183,6 +198,7 @@ async function runRelease(): Promise<void> {
 	}
 
 	syncNativeManifests();
+	deletePrivateSdkChangelogs();
 	execSync('pnpm install --no-frozen-lockfile', { stdio: 'inherit' });
 }
 

--- a/.github/changeset-version.ts
+++ b/.github/changeset-version.ts
@@ -3,8 +3,9 @@
  *
  * Modes:
  *   - `validate`: rejects malformed changesets and `none`-bumped SDK changesets. Run in PR CI.
- *   - `release`:  validates, expands every changeset to all SDKs, runs `changeset version`,
- *                 syncs native manifests, refreshes the lockfile. Run by changesets/action.
+ *   - `release`:  validates, rewrites SDK changesets to the canonical npm package,
+ *                 runs `changeset version`, syncs private SDK versions and native
+ *                 manifests, refreshes native and pnpm lockfiles. Run by changesets/action.
  *
  * An SDK is any direct subdirectory of `sdks/` containing a `package.json`.
  */
@@ -18,6 +19,7 @@ import { parse as parseToml, patch as patchToml } from '@decimalturn/toml-patch'
 import { getPackagesSync, type Package } from '@manypkg/get-packages';
 
 const ROOT = process.cwd();
+const CANONICAL_PACKAGE_NAME = '@cloudflare/flagship';
 const BUMP_RANK: Record<VersionType, number> = { none: 0, patch: 1, minor: 2, major: 3 };
 
 function readSdkPackages(): Package[] {
@@ -61,26 +63,36 @@ export async function validatePendingChangesets(): Promise<void> {
 	console.log(changesets.length === 0 ? 'No pending changesets to validate.' : `Validated ${changesets.length} pending changeset(s).`);
 }
 
-/** Every release-bound changeset is rewritten to bump every SDK at the highest SDK bump present. */
-export async function expandChangesetsToAllSdks(): Promise<void> {
-	const allSdkNames = readSdkPackages()
-		.map((pkg) => pkg.packageJson.name)
-		.sort();
-	const sdkNames = new Set(allSdkNames);
+function readCanonicalPackage(): Package {
+	const canonical = readSdkPackages().find((pkg) => pkg.packageJson.name === CANONICAL_PACKAGE_NAME);
+	if (canonical === undefined) {
+		throw new Error(`Canonical SDK package not found: ${CANONICAL_PACKAGE_NAME}`);
+	}
+	return canonical;
+}
+
+/**
+ * The repo uses a single public release package for Changesets output. Private SDKs
+ * still get version-synced, but they are removed from release entries so the release
+ * PR body and changelog don't duplicate the same notes for every language.
+ */
+export async function rewriteChangesetsToCanonicalPackage(): Promise<void> {
+	const sdkNames = new Set(readSdkPackages().map((pkg) => pkg.packageJson.name));
 
 	for (const changeset of await readChangesets(ROOT)) {
 		const sdkReleases = changeset.releases.filter((release) => sdkNames.has(release.name));
 		if (sdkReleases.length === 0) continue;
 
-		const present = new Set(changeset.releases.map((release) => release.name));
-		const missing = allSdkNames.filter((name) => !present.has(name));
-		if (missing.length === 0) continue;
-
 		const bump = highestBump(sdkReleases.map((release) => release.type));
-		const expanded: Release[] = [...changeset.releases, ...missing.map((name) => ({ name, type: bump }))];
+		const rewritten: Release[] = [{ name: CANONICAL_PACKAGE_NAME, type: bump }];
+		const alreadyCanonical =
+			changeset.releases.length === rewritten.length &&
+			changeset.releases[0]?.name === CANONICAL_PACKAGE_NAME &&
+			changeset.releases[0]?.type === bump;
+		if (alreadyCanonical) continue;
 
-		writeChangesetFile({ id: changeset.id, summary: changeset.summary, releases: expanded });
-		console.log(`Expanded .changeset/${changeset.id}.md to all SDKs at bump '${bump}'.`);
+		writeChangesetFile({ id: changeset.id, summary: changeset.summary, releases: rewritten });
+		console.log(`Rewrote .changeset/${changeset.id}.md to ${CANONICAL_PACKAGE_NAME} at bump '${bump}'.`);
 	}
 }
 
@@ -91,6 +103,21 @@ function highestBump(bumps: VersionType[]): VersionType {
 function writeChangesetFile({ id, summary, releases }: NewChangeset): void {
 	const frontmatter = releases.map((release) => `"${release.name}": ${release.type}`).join('\n');
 	writeFileSync(join(ROOT, '.changeset', `${id}.md`), `---\n${frontmatter}\n---\n\n${summary}\n`);
+}
+
+/** Syncs private SDK package.json versions to the canonical public package version. */
+export function syncPrivateSdkPackageVersions(): void {
+	const targetVersion = readCanonicalPackage().packageJson.version;
+
+	for (const pkg of readSdkPackages()) {
+		if (pkg.packageJson.private !== true) continue;
+		if (pkg.packageJson.version === targetVersion) continue;
+
+		const packageJsonPath = join(pkg.dir, 'package.json');
+		const packageJson = `${JSON.stringify({ ...pkg.packageJson, version: targetVersion }, null, '\t')}\n`;
+		writeFileSync(packageJsonPath, packageJson);
+		console.log(`Synced ${relative(ROOT, packageJsonPath)} -> ${targetVersion}.`);
+	}
 }
 
 /** Mirrors each SDK's `package.json` version into the native manifest beside it, if present. */
@@ -105,6 +132,26 @@ export function syncNativeManifests(): void {
 
 	if (errors.length > 0) {
 		throw new Error(`Native manifest sync failed:\n  - ${errors.join('\n  - ')}`);
+	}
+}
+
+/**
+ * Regenerate native lockfiles after manifest version bumps so the release PR
+ * contains an up-to-date lockfile. Skipped silently when the relevant CLI is
+ * not on PATH (e.g. local dev environments without `uv` installed).
+ */
+export function refreshNativeLockfiles(): void {
+	for (const pkg of readSdkPackages()) {
+		const pyprojectPath = join(pkg.dir, 'pyproject.toml');
+		const uvLockPath = join(pkg.dir, 'uv.lock');
+		if (existsSync(pyprojectPath) && existsSync(uvLockPath)) {
+			try {
+				execSync('uv lock', { cwd: pkg.dir, stdio: 'inherit' });
+				console.log(`Refreshed ${relative(ROOT, uvLockPath)}.`);
+			} catch (error) {
+				throw new Error(`Failed to refresh ${relative(ROOT, uvLockPath)}: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}
 	}
 }
 
@@ -188,7 +235,7 @@ async function runRelease(): Promise<void> {
 	);
 
 	try {
-		await expandChangesetsToAllSdks();
+		await rewriteChangesetsToCanonicalPackage();
 		execSync('pnpm changeset version', { stdio: 'inherit' });
 	} catch (error) {
 		for (const [file, content] of snapshot) {
@@ -197,7 +244,9 @@ async function runRelease(): Promise<void> {
 		throw error;
 	}
 
+	syncPrivateSdkPackageVersions();
 	syncNativeManifests();
+	refreshNativeLockfiles();
 	deletePrivateSdkChangelogs();
 	execSync('pnpm install --no-frozen-lockfile', { stdio: 'inherit' });
 }

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,7 +3,7 @@ name: Publish PyPI
 on:
   push:
     tags:
-      - '@cloudflare/flagship-python@*'
+      - '**/flagship@*'
 
 permissions:
   contents: read

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,37 +1,14 @@
 name: Publish PyPI
 
 on:
-  push:
-    tags:
-      - '**/flagship@*'
+  workflow_call:
 
 permissions:
   contents: read
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
-      - run: uv run ruff format --check .
-        working-directory: sdks/python
-
-      - run: uv run ruff check .
-        working-directory: sdks/python
-
-      - run: uv run --group dev mypy
-        working-directory: sdks/python
-
-      - run: uv run --group dev pytest
-        working-directory: sdks/python
-
   publish:
     name: Publish
-    needs: check
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -88,7 +88,6 @@ jobs:
     name: TypeScript Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: typescript-build
     steps:
       - uses: actions/checkout@v6
 
@@ -99,14 +98,12 @@ jobs:
           node-version: 24
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
       - run: pnpm run typecheck
 
   typescript-test:
     name: TypeScript Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: typescript-build
     steps:
       - uses: actions/checkout@v6
 
@@ -146,9 +143,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           working-directory: sdks/python
+
+      - run: uv sync --group dev --locked
+        working-directory: sdks/python
 
       - run: uv run ruff format --check .
         working-directory: sdks/python
@@ -160,9 +160,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           working-directory: sdks/python
+
+      - run: uv sync --group dev --locked
+        working-directory: sdks/python
 
       - run: uv run ruff check .
         working-directory: sdks/python
@@ -174,7 +177,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           working-directory: sdks/python
 
@@ -185,28 +188,32 @@ jobs:
     name: Python Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: python-build
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           working-directory: sdks/python
 
-      - run: uv run --group dev mypy
+      - run: uv sync --group dev --locked
+        working-directory: sdks/python
+
+      - run: uv run mypy
         working-directory: sdks/python
 
   python-test:
     name: Python Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: python-build
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           working-directory: sdks/python
 
-      - run: uv run --group dev pytest
+      - run: uv sync --group dev --locked
+        working-directory: sdks/python
+
+      - run: uv run pytest
         working-directory: sdks/python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          working-directory: sdks/python
+
+      - run: uv sync --group dev --locked
+        working-directory: sdks/python
 
       - run: uv run ruff format --check .
         working-directory: sdks/python
@@ -46,10 +51,10 @@ jobs:
       - run: uv run ruff check .
         working-directory: sdks/python
 
-      - run: uv run --group dev mypy
+      - run: uv run mypy
         working-directory: sdks/python
 
-      - run: uv run --group dev pytest
+      - run: uv run pytest
         working-directory: sdks/python
 
   publish:
@@ -57,6 +62,8 @@ jobs:
     needs: [check-typescript, check-python]
     if: ${{ github.repository_owner == 'cloudflare' }}
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     permissions:
       id-token: write
       contents: write
@@ -73,10 +80,15 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          working-directory: sdks/python
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
 
-      - uses: changesets/action@v1.7.0
+      - id: changesets
+        uses: changesets/action@v1.7.0
         with:
           version: pnpm tsx .github/changeset-version.ts
           publish: pnpm changeset publish
@@ -86,3 +98,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+  publish-pypi:
+    name: Publish PyPI
+    needs: publish
+    if: ${{ needs.publish.outputs.published == 'true' }}
+    uses: ./.github/workflows/publish-pypi.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 jobs:
-  check:
-    name: Check
+  check-typescript:
+    name: Check (TypeScript)
     if: ${{ github.repository_owner == 'cloudflare' }}
     runs-on: ubuntu-latest
     steps:
@@ -31,9 +31,30 @@ jobs:
       - run: pnpm run check
       - run: pnpm run test
 
+  check-python:
+    name: Check (Python)
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - run: uv run ruff format --check .
+        working-directory: sdks/python
+
+      - run: uv run ruff check .
+        working-directory: sdks/python
+
+      - run: uv run --group dev mypy
+        working-directory: sdks/python
+
+      - run: uv run --group dev pytest
+        working-directory: sdks/python
+
   publish:
     name: Publish
-    needs: check
+    needs: [check-typescript, check-python]
     if: ${{ github.repository_owner == 'cloudflare' }}
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,23 +160,24 @@ Changes to published packages need a changeset:
 pnpm changeset      # interactive prompt — pick packages, semver bump, description
 ```
 
-Pick only the SDK package(s) you actually changed. The release workflow expands every release-bound changeset so all SDK packages are bumped to the same version. The highest bump in the changeset (`patch` < `minor` < `major`) becomes the bump for the rest.
+Pick the SDK package you changed. During release, SDK changesets are rewritten to the canonical public package (`@cloudflare/flagship`) so the release PR has one changelog section and one tag. Private SDK versions are then synchronized to the same version.
 
 The release pipeline runs `.github/changeset-version.ts`, which:
 
 1. Validates every pending changeset — fails fast on unknown packages, non-SDK-only changesets, or SDK entries with a `none` bump.
-2. Expands the changeset to include every SDK package so they share the bump.
-3. Runs `pnpm changeset version`, producing one PR titled `chore(release): version SDK packages` with all SDK `package.json` updates and the TypeScript SDK changelog update.
-4. Syncs the new version into native manifests beside each SDK:
+2. Rewrites SDK changesets to `@cloudflare/flagship` using the highest SDK bump in each changeset.
+3. Runs `pnpm changeset version`, producing one PR titled `chore(release): version SDK packages` with the TypeScript SDK changelog update.
+4. Syncs the canonical version into private SDK `package.json` files and native manifests beside each SDK:
    - `pyproject.toml` — updates `[project].version` (PEP 621, used by uv/hatch/flit/pdm and Poetry 2.0+) and/or `[tool.poetry].version` (legacy Poetry 1.x), whichever fields are present. Fails if neither exists.
    - `Cargo.toml` — updates `[package].version` only. Dependency `version` fields are left untouched.
    - `go.mod` — no file sync. Go modules are versioned exclusively via git tags.
-5. Re-runs `pnpm install` to refresh the lockfile.
+5. Deletes duplicate changelogs generated for private SDK packages.
+6. Re-runs `pnpm install` to refresh the lockfile.
 
 After merge the same workflow runs `pnpm changeset publish` and:
 
-- Publishes public npm SDKs (currently `@cloudflare/flagship`).
-- Skips npm publish for `private: true` SDKs but still creates a git tag (`privatePackages.tag: true`). The Python PyPI workflow subscribes to `@cloudflare/flagship-python@*` tags and publishes via PyPI trusted publishing (OIDC, no PyPI token). For Go, the git tag is the version — no additional file sync is needed.
+- Publishes public npm SDKs (currently `@cloudflare/flagship`) and creates the canonical `@cloudflare/flagship@*` git tag.
+- Skips npm publish and tag creation for `private: true` SDKs (`privatePackages.tag: false`). The Python PyPI workflow subscribes to the canonical `@cloudflare/flagship@*` tag and publishes via PyPI trusted publishing (OIDC, no PyPI token). For Go, the canonical release tag is the version signal — no additional file sync is needed.
 
 Every releasable SDK must have a `package.json` so Changesets can discover and version it, even if the actual package is published to PyPI, crates.io, Go modules, or another registry. Non-npm SDK packages should use `private: true` and keep their native manifest beside it:
 
@@ -203,7 +204,7 @@ The PR workflow is split by SDK:
 Publishing workflows are language-specific:
 
 - `release.yml` (`Publish npm`) runs on pushes to `main`; Changesets creates release PRs and publishes npm packages after the release PR is merged.
-- `publish-pypi.yml` runs on `@cloudflare/flagship-python@*` tags; it runs Python checks, builds the Python package, and publishes to PyPI with trusted publishing.
+- `publish-pypi.yml` runs on canonical `@cloudflare/flagship@*` tags; it runs Python checks, builds the Python package, and publishes to PyPI with trusted publishing.
 
 ## Boundaries
 

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "cloudflare-flagship"
-version = "0.0.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes the release pipeline so the PyPI publish actually fires after the automated release PR is merged, runs Python checks before any tag is created, and produces a clean release PR with a single changelog section per version.

## Changes

### Release flow
- `release.yml` now runs TypeScript and Python checks in parallel before `changesets/action` runs. Tag creation and npm publish only happen if both pass.
- PyPI publish is no longer triggered by a tag push (which never fired reliably due to the `/` in `@cloudflare/flagship-python@*`). `publish-pypi.yml` is now a reusable workflow called directly from `release.yml`, gated on `steps.changesets.outputs.published == 'true'` — so PyPI only publishes on actual releases, not every merge to `main`.
- `publish-pypi.yml` no longer re-runs Python checks (already validated in `release.yml`).

### Single canonical release package
- `changeset-version.ts` now rewrites every SDK changeset to target `@cloudflare/flagship`, so the release PR body and changelog only show one section per version.
- Private SDK versions (`@cloudflare/flagship-python`) are still synced to match, but they no longer appear as separate release entries.
- `privatePackages.tag` set to `false` — only one git tag per release (`@cloudflare/flagship@x.y.z`).
- Generated `sdks/python/CHANGELOG.md` is deleted automatically after `pnpm changeset version`.

### Native lockfile sync
- `changeset-version.ts` now runs `uv lock` after bumping `sdks/python/pyproject.toml`, so the release PR includes an up-to-date `uv.lock`. Without this, `uv sync --locked` in CI would fail when processing the release PR.
- `setup-uv` added to the publish job in `release.yml` so `uv lock` is available during the version step.

### Workflow consistency cleanup
- All `astral-sh/setup-uv` references pinned to SHA across `release.yml`, `publish-pypi.yml`, and `pull-request.yml`.
- Python jobs now run `uv sync --group dev --locked` once, then invoke tools directly — no more per-tool auto-sync.
- Removed wasteful `needs: typescript-build` and `needs: python-build` dependencies from typecheck/test jobs in `pull-request.yml`. Those jobs were sequentially gated on a build whose artifacts they never consumed.
- Removed redundant `permissions` block on the reusable-workflow caller (reusable workflows define their own).

## Release flow after this PR

1. Merge a PR with a changeset → `release.yml` runs checks → `changesets/action` creates/updates the release PR.
2. Merge the release PR → `release.yml` runs checks again → `changesets/action` publishes `@cloudflare/flagship` to npm and creates the tag → `publish-pypi.yml` is invoked → PyPI publishes via OIDC trusted publishing.

Regular merges to `main` (no changesets) run the checks but skip publish entirely.