### PR TITLE
feat: remove provider initialization health-check

### DIFF
--- a/.changeset/remove-init-health-checks.md
+++ b/.changeset/remove-init-health-checks.md
@@ -1,0 +1,6 @@
+---
+'@cloudflare/flagship': patch
+'@cloudflare/flagship-python': patch
+---
+
+Remove provider initialization health-check evaluations.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -176,10 +176,9 @@ api.add_hooks([TelemetryHook(lambda event: analytics.track("flag_evaluated", eve
 from openfeature.event import ProviderEvent
 
 api.add_handler(ProviderEvent.PROVIDER_READY, lambda _: print("ready"))
-api.add_handler(ProviderEvent.PROVIDER_ERROR, lambda d: print("error:", d.message))
 ```
 
-During initialisation the provider probes the endpoint with a health-check request. A 404 is treated as success. Any other error transitions the provider to `ERROR` status and emits `PROVIDER_ERROR`.
+Initialization does not perform network I/O. Flag evaluation requests happen only when resolving flags.
 
 ## Development
 

--- a/sdks/python/src/flagship/provider.py
+++ b/sdks/python/src/flagship/provider.py
@@ -3,9 +3,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from openfeature.evaluation_context import EvaluationContext
-from openfeature.event import ProviderEventDetails
 from openfeature.exception import (
-    FlagNotFoundError,
     GeneralError,
     TypeMismatchError,
 )
@@ -16,15 +14,13 @@ from openfeature.flag_evaluation import (
     Reason,
 )
 from openfeature.hook import Hook
-from openfeature.provider import AbstractProvider, Metadata, ProviderStatus
+from openfeature.provider import AbstractProvider, Metadata
 
 from .client import FLAGSHIP_DEFAULT_BASE_URL, FlagshipClient
 
 __all__ = ["FlagshipServerProvider"]
 
 _logger = logging.getLogger("flagship")
-
-_HEALTH_CHECK_FLAG = "_flagship_health_check"
 
 _TYPE_MAP: dict[FlagType, type | tuple[type, ...]] = {
     FlagType.BOOLEAN: bool,
@@ -79,7 +75,6 @@ class FlagshipServerProvider(AbstractProvider):
             retry_delay=retry_delay,
         )
         self._logging = logging
-        self._status: ProviderStatus = ProviderStatus.NOT_READY
 
     def get_metadata(self) -> Metadata:
         return Metadata(name="Flagship Server Provider")
@@ -87,34 +82,10 @@ class FlagshipServerProvider(AbstractProvider):
     def get_provider_hooks(self) -> list[Hook]:
         return []
 
-    @property
-    def status(self) -> ProviderStatus:
-        return self._status
-
-    def initialize(self, evaluation_context: EvaluationContext) -> None:
-        """Probe the evaluation endpoint.
-
-        A 404 response is treated as success — it means the endpoint is reachable
-        but the health-check flag simply doesn't exist, which is expected.
-        """
-        try:
-            self._client.evaluate(_HEALTH_CHECK_FLAG, EvaluationContext())
-        except FlagNotFoundError:
-            pass
-        except Exception as e:
-            self._status = ProviderStatus.ERROR
-            self._log_error("Flagship initialization failed: %s", e)
-            self.emit_provider_error(ProviderEventDetails(message=str(e)))
-            return
-        self._status = ProviderStatus.READY
-        self.emit_provider_ready(ProviderEventDetails())
-
     def shutdown(self) -> None:
-        self._status = ProviderStatus.NOT_READY
         self._client.close()
 
     async def shutdown_async(self) -> None:
-        self._status = ProviderStatus.NOT_READY
         await self._client.aclose()
 
     def resolve_boolean_details(

--- a/sdks/python/tests/test_provider.py
+++ b/sdks/python/tests/test_provider.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
 import respx
+from openfeature import api
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.exception import (
     FlagNotFoundError,
@@ -28,32 +29,15 @@ def _resp(value: object, *, reason: str = "TARGETING_MATCH", variant: str = "on"
 
 
 @respx.mock
-def test_initialize_succeeds_on_200(provider: FlagshipServerProvider) -> None:
-    respx.get(url__regex=ENDPOINT_REGEX).mock(return_value=_resp(True))
-    provider.initialize(EvaluationContext())
-    assert provider.status == ProviderStatus.READY
+def test_set_provider_does_not_request_endpoint(provider: FlagshipServerProvider) -> None:
+    api.set_provider(provider)
+    assert len(respx.calls) == 0
+    assert api.get_client().get_provider_status() == ProviderStatus.READY
+    api.clear_providers()
 
 
-@respx.mock
-def test_initialize_treats_404_as_ready(provider: FlagshipServerProvider) -> None:
-    respx.get(url__regex=ENDPOINT_REGEX).mock(return_value=httpx.Response(404))
-    provider.initialize(EvaluationContext())
-    assert provider.status == ProviderStatus.READY
-
-
-@respx.mock
-def test_initialize_failure_sets_error_status(
-    provider: FlagshipServerProvider,
-) -> None:
-    respx.get(url__regex=ENDPOINT_REGEX).mock(return_value=httpx.Response(500))
-    provider.initialize(EvaluationContext())
-    assert provider.status == ProviderStatus.ERROR
-
-
-def test_shutdown_resets_status(provider: FlagshipServerProvider) -> None:
-    provider._status = ProviderStatus.READY  # type: ignore[attr-defined]
+def test_shutdown_closes_client(provider: FlagshipServerProvider) -> None:
     provider.shutdown()
-    assert provider.status == ProviderStatus.NOT_READY
 
 
 def test_metadata_name(provider: FlagshipServerProvider) -> None:

--- a/sdks/typescript/API.md
+++ b/sdks/typescript/API.md
@@ -392,24 +392,19 @@ OpenFeature.addHandler(ProviderEvents.Ready, () => {
   console.log('Provider initialized and ready');
 });
 
-OpenFeature.addHandler(ProviderEvents.Error, ({ message }) => {
-  console.error('Provider failed to initialize:', message);
-});
-
 await OpenFeature.setProviderAndWait(provider);
 ```
 
-**Server provider (HTTP mode):** During initialization, the provider probes the evaluation endpoint with a health-check request. A 404 response (flag not found) is treated as success — it means the endpoint is reachable. Any network or timeout error causes `ProviderEvents.Error` to be emitted, but `setProviderAndWait` still resolves (does not reject) — the provider transitions to `ERROR` status silently.
+**Server provider:** Initialization does not perform network I/O. Flag evaluation requests happen only when resolving flags.
 
-**Server provider (binding mode):** Initialization sets READY immediately — the binding is guaranteed to be available by the Workers runtime. No health-check probe is performed.
+**Server provider (binding mode):** Initialization does not call binding methods. Binding evaluation requests happen only when resolving flags.
 
 **Client provider:** During initialization, the provider fetches all `prefetchFlags` using `Promise.allSettled`. Even if some or all fetches fail, the provider transitions to `READY` status. Failed flags return `FLAG_NOT_FOUND` when resolved.
 
-To shut down the provider and release resources:
+To shut down providers and release resources:
 
 ```typescript
-await provider.onClose();
-// provider.status === ProviderStatus.NOT_READY
+await OpenFeature.clearProviders();
 // Client provider also clears the in-memory cache
 ```
 

--- a/sdks/typescript/src/server-provider.ts
+++ b/sdks/typescript/src/server-provider.ts
@@ -1,5 +1,5 @@
 import type { Provider, ResolutionDetails, EvaluationContext, JsonValue, ProviderMetadata, Logger } from '@openfeature/server-sdk';
-import { ErrorCode, ProviderStatus, OpenFeatureEventEmitter, ProviderEvents } from '@openfeature/server-sdk';
+import { ErrorCode, OpenFeatureEventEmitter } from '@openfeature/server-sdk';
 import { FlagshipClient } from './client.js';
 import {
 	FlagshipError,
@@ -79,7 +79,6 @@ export class FlagshipServerProvider implements Provider {
 	/** Set when operating in binding mode; `undefined` in HTTP mode. */
 	private readonly binding: FlagshipBinding | undefined;
 	private readonly logging: boolean;
-	private currentStatus: ProviderStatus = ProviderStatus.NOT_READY;
 
 	private readonly resolve: <T>(
 		flagKey: string,
@@ -120,48 +119,6 @@ export class FlagshipServerProvider implements Provider {
 	private logger(logger: Logger): Logger {
 		if (this.logging) return logger;
 		return { debug: _noop, info: _noop, warn: _noop, error: _noop };
-	}
-
-	/**
-	 * Initializes the provider.
-	 *
-	 * **HTTP mode**: probes the evaluation endpoint with a health-check request.
-	 * A 404 response is treated as success — it means the endpoint is reachable
-	 * but the health-check flag simply doesn't exist, which is expected.
-	 *
-	 * **Binding mode**: sets READY immediately — the binding is guaranteed to
-	 * be available by the Workers runtime.
-	 */
-	async initialize(_context?: EvaluationContext): Promise<void> {
-		if (this.binding) {
-			// Binding mode: the runtime guarantees the binding is available.
-			this.currentStatus = ProviderStatus.READY;
-			this.events.emit(ProviderEvents.Ready);
-			return;
-		}
-
-		// HTTP mode: health-check probe.
-		try {
-			await this.client!.evaluate('_flagship_health_check', {});
-			this.currentStatus = ProviderStatus.READY;
-			this.events.emit(ProviderEvents.Ready);
-		} catch (error) {
-			if (error instanceof FlagshipError && error.cause instanceof Response && error.cause.status === 404) {
-				this.currentStatus = ProviderStatus.READY;
-				this.events.emit(ProviderEvents.Ready);
-				return;
-			}
-			this.currentStatus = ProviderStatus.ERROR;
-			this.events.emit(ProviderEvents.Error, { message: error instanceof Error ? error.message : String(error) });
-		}
-	}
-
-	async onClose(): Promise<void> {
-		this.currentStatus = ProviderStatus.NOT_READY;
-	}
-
-	get status(): ProviderStatus {
-		return this.currentStatus;
 	}
 
 	async resolveBooleanEvaluation(

--- a/sdks/typescript/tests/binding-provider.test.ts
+++ b/sdks/typescript/tests/binding-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Logger } from '@openfeature/server-sdk';
-import { ErrorCode, ProviderStatus, ProviderEvents, OpenFeature } from '@openfeature/server-sdk';
+import { ErrorCode, ProviderEvents, OpenFeature } from '@openfeature/server-sdk';
 import { FlagshipServerProvider } from '../src/server-provider.js';
 import type { FlagshipBinding, FlagshipBindingEvaluationDetails } from '../src/types.js';
 
@@ -46,6 +46,8 @@ const noopLogger: Logger = {
 describe('FlagshipServerProvider (binding mode)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		OpenFeature.clearHandlers();
+		OpenFeature.clearProviders();
 	});
 
 	// -----------------------------------------------------------------------
@@ -169,23 +171,10 @@ describe('FlagshipServerProvider (binding mode)', () => {
 	// -----------------------------------------------------------------------
 
 	describe('lifecycle', () => {
-		it('status is NOT_READY before initialize', () => {
+		it('setProviderAndWait does not call binding methods', async () => {
 			const binding = createMockBinding();
 			const provider = new FlagshipServerProvider({ binding });
-			expect(provider.status).toBe(ProviderStatus.NOT_READY);
-		});
-
-		it('status is READY immediately after initialize (no health check)', async () => {
-			const binding = createMockBinding();
-			const provider = new FlagshipServerProvider({ binding });
-			await provider.initialize();
-			expect(provider.status).toBe(ProviderStatus.READY);
-		});
-
-		it('does not call any binding methods during initialize', async () => {
-			const binding = createMockBinding();
-			const provider = new FlagshipServerProvider({ binding });
-			await provider.initialize();
+			await OpenFeature.setProviderAndWait(provider);
 
 			expect(binding.get).not.toHaveBeenCalled();
 			expect(binding.getBooleanDetails).not.toHaveBeenCalled();
@@ -194,25 +183,15 @@ describe('FlagshipServerProvider (binding mode)', () => {
 			expect(binding.getObjectDetails).not.toHaveBeenCalled();
 		});
 
-		it('emits READY event on initialize', async () => {
+		it('setProviderAndWait emits READY', async () => {
 			const binding = createMockBinding();
 			const provider = new FlagshipServerProvider({ binding });
 			const readyHandler = vi.fn();
-			provider.events.addHandler(ProviderEvents.Ready, readyHandler);
+			OpenFeature.addHandler(ProviderEvents.Ready, readyHandler);
 
-			await provider.initialize();
+			await OpenFeature.setProviderAndWait(provider);
 
 			expect(readyHandler).toHaveBeenCalled();
-		});
-
-		it('status resets to NOT_READY after onClose', async () => {
-			const binding = createMockBinding();
-			const provider = new FlagshipServerProvider({ binding });
-			await provider.initialize();
-			expect(provider.status).toBe(ProviderStatus.READY);
-
-			await provider.onClose();
-			expect(provider.status).toBe(ProviderStatus.NOT_READY);
 		});
 	});
 

--- a/sdks/typescript/tests/hooks/hooks.test.ts
+++ b/sdks/typescript/tests/hooks/hooks.test.ts
@@ -19,16 +19,6 @@ describe('Hooks', () => {
 			const logMessages: any[] = [];
 			const logger = vi.fn((...args: any[]) => logMessages.push(args));
 
-			// First mock for initialization health check
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					flagKey: '_flagship_health_check',
-					value: true,
-				}),
-			});
-
-			// Second mock for actual flag evaluation
 			(global.fetch as any).mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({
@@ -64,13 +54,6 @@ describe('Hooks', () => {
 			const logMessages: any[] = [];
 			const logger = vi.fn((...args: any[]) => logMessages.push(args));
 
-			// First mock for initialization
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			// Second mock for actual flag evaluation (error)
 			(global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
 
 			await OpenFeature.setProviderAndWait(
@@ -98,13 +81,6 @@ describe('Hooks', () => {
 		it('should use default console.log if no logger provided', async () => {
 			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
-			// First mock for initialization
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			// Second mock for actual flag evaluation
 			(global.fetch as any).mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({
@@ -135,13 +111,6 @@ describe('Hooks', () => {
 			const events: TelemetryEvent[] = [];
 			const onEvent = vi.fn((event: TelemetryEvent) => events.push(event));
 
-			// First mock for initialization
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			// Second mock for actual flag evaluation
 			(global.fetch as any).mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({
@@ -182,13 +151,6 @@ describe('Hooks', () => {
 			const events: TelemetryEvent[] = [];
 			const onEvent = vi.fn((event: TelemetryEvent) => events.push(event));
 
-			// First mock for initialization
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			// Second mock for actual flag evaluation (error)
 			(global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
 
 			await OpenFeature.setProviderAndWait(
@@ -217,13 +179,6 @@ describe('Hooks', () => {
 			const events: TelemetryEvent[] = [];
 			const onEvent = vi.fn((event: TelemetryEvent) => events.push(event));
 
-			// First mock for initialization
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			// Mock two successful evaluations
 			(global.fetch as any)
 				.mockResolvedValueOnce({
 					ok: true,
@@ -255,13 +210,6 @@ describe('Hooks', () => {
 			const events: TelemetryEvent[] = [];
 			const onEvent = vi.fn((event: TelemetryEvent) => events.push(event));
 
-			// First mock for initialization
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			// Second mock for actual evaluation
 			(global.fetch as any).mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({ flagKey: 'test-flag', value: true }),
@@ -296,13 +244,6 @@ describe('Hooks', () => {
 			const events: TelemetryEvent[] = [];
 			const onEvent = vi.fn((event: TelemetryEvent) => events.push(event));
 
-			// First mock for initialization
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			// Second mock for actual evaluation
 			(global.fetch as any).mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({ flagKey: 'test-flag', value: true }),

--- a/sdks/typescript/tests/integration.test.ts
+++ b/sdks/typescript/tests/integration.test.ts
@@ -21,7 +21,6 @@ describe('Flagship Integration Tests', () => {
 
 	describe('Server Provider Integration', () => {
 		it('should integrate with OpenFeature server SDK', async () => {
-			// Mock API response
 			(global.fetch as any).mockResolvedValue({
 				ok: true,
 				json: async () => ({
@@ -30,7 +29,6 @@ describe('Flagship Integration Tests', () => {
 				}),
 			});
 
-			// Set up provider
 			await OpenFeature.setProviderAndWait(
 				new FlagshipServerProvider({
 					endpoint: 'https://api.example.com/evaluate',
@@ -39,17 +37,15 @@ describe('Flagship Integration Tests', () => {
 
 			const client = OpenFeature.getClient();
 
-			// Evaluate flag
 			const value = await client.getBooleanValue('feature-flag', false, {
 				targetingKey: 'user-123',
 				email: 'user@example.com',
 			});
 
 			expect(value).toBe(true);
-			expect(global.fetch).toHaveBeenCalledTimes(2); // Init + evaluation
+			expect(global.fetch).toHaveBeenCalledTimes(1);
 
-			// Verify the URL contains context (second call is the actual evaluation)
-			const callArgs = (global.fetch as any).mock.calls[1];
+			const callArgs = (global.fetch as any).mock.calls[0];
 			const url = new URL(callArgs[0]);
 			expect(url.searchParams.get('flagKey')).toBe('feature-flag');
 			expect(url.searchParams.get('targetingKey')).toBe('user-123');
@@ -209,12 +205,7 @@ describe('Flagship Integration Tests', () => {
 		});
 
 		it('should handle multiple sequential evaluations', async () => {
-			// Mock all responses
 			(global.fetch as any)
-				.mockResolvedValueOnce({
-					ok: true,
-					json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-				})
 				.mockResolvedValueOnce({
 					ok: true,
 					json: async () => ({ flagKey: 'flag1', value: true }),
@@ -242,7 +233,7 @@ describe('Flagship Integration Tests', () => {
 
 			expect(value1).toBe(true);
 			expect(value2).toBe('variant-b');
-			expect(global.fetch).toHaveBeenCalledTimes(3); // Init + 2 evaluations
+			expect(global.fetch).toHaveBeenCalledTimes(2);
 		});
 
 		it('should work with empty context', async () => {
@@ -265,8 +256,7 @@ describe('Flagship Integration Tests', () => {
 
 			expect(value).toBe(true);
 
-			// Verify URL only has flagKey (second call is the actual evaluation)
-			const callArgs = (global.fetch as any).mock.calls[1];
+			const callArgs = (global.fetch as any).mock.calls[0];
 			const url = new URL(callArgs[0]);
 			expect(url.searchParams.get('flagKey')).toBe('default-feature');
 			expect(url.searchParams.get('targetingKey')).toBeNull();

--- a/sdks/typescript/tests/server-provider-events.test.ts
+++ b/sdks/typescript/tests/server-provider-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { OpenFeature, ProviderEvents, ProviderStatus } from '@openfeature/server-sdk';
+import { OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
 import { FlagshipServerProvider } from '../src/server-provider.js';
 
 // Mock fetch globally
@@ -8,6 +8,7 @@ global.fetch = vi.fn();
 describe('Provider Events', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		OpenFeature.clearHandlers();
 		OpenFeature.clearProviders();
 	});
 
@@ -15,59 +16,16 @@ describe('Provider Events', () => {
 		it('should emit READY event on successful initialization', async () => {
 			const readyHandler = vi.fn();
 
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
 			const provider = new FlagshipServerProvider({
 				endpoint: 'https://api.example.com/evaluate',
 			});
 
-			provider.events.addHandler(ProviderEvents.Ready, readyHandler);
+			OpenFeature.addHandler(ProviderEvents.Ready, readyHandler);
 
 			await OpenFeature.setProviderAndWait(provider);
 
 			expect(readyHandler).toHaveBeenCalled();
-		});
-
-		it('should emit ERROR event on network failure during initialization', async () => {
-			const errorHandler = vi.fn();
-
-			(global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
-
-			const provider = new FlagshipServerProvider({
-				endpoint: 'https://api.example.com/evaluate',
-				retries: 0,
-			});
-
-			provider.events.addHandler(ProviderEvents.Error, errorHandler);
-
-			await OpenFeature.setProviderAndWait(provider);
-
-			expect(errorHandler).toHaveBeenCalled();
-			expect(provider.status).toBe(ProviderStatus.ERROR);
-		});
-
-		it('should emit READY event when health check returns 404 (endpoint reachable)', async () => {
-			const readyHandler = vi.fn();
-
-			// Must use a real Response instance so `instanceof Response` succeeds
-			// in the 404 detection path inside initialize().
-			const mockResponse = new Response(null, { status: 404, statusText: 'Not Found' });
-			(global.fetch as any).mockResolvedValueOnce(mockResponse);
-
-			const provider = new FlagshipServerProvider({
-				endpoint: 'https://api.example.com/evaluate',
-				retries: 0,
-			});
-
-			provider.events.addHandler(ProviderEvents.Ready, readyHandler);
-
-			await OpenFeature.setProviderAndWait(provider);
-
-			expect(readyHandler).toHaveBeenCalled();
-			expect(provider.status).toBe(ProviderStatus.READY);
+			expect(global.fetch).not.toHaveBeenCalled();
 		});
 
 		it('should handle initialization without explicit initialize call', async () => {
@@ -102,33 +60,7 @@ describe('Provider Events', () => {
 
 			await OpenFeature.setProviderAndWait(provider);
 
-			// Shutdown should not throw
-			await expect(provider.onClose()).resolves.not.toThrow();
-		});
-	});
-
-	describe('Provider Status', () => {
-		it('should start with NOT_READY status', () => {
-			const provider = new FlagshipServerProvider({
-				endpoint: 'https://api.example.com/evaluate',
-			});
-
-			expect(provider.status).toBeDefined();
-		});
-
-		it('should be READY after initialization', async () => {
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			const provider = new FlagshipServerProvider({
-				endpoint: 'https://api.example.com/evaluate',
-			});
-
-			await OpenFeature.setProviderAndWait(provider);
-
-			expect(provider.status).toBeDefined();
+			await expect(OpenFeature.clearProviders()).resolves.not.toThrow();
 		});
 	});
 
@@ -136,18 +68,12 @@ describe('Provider Events', () => {
 		it('should allow adding multiple event handlers', async () => {
 			const handler1 = vi.fn();
 			const handler2 = vi.fn();
-
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
 			const provider = new FlagshipServerProvider({
 				endpoint: 'https://api.example.com/evaluate',
 			});
 
-			provider.events.addHandler(ProviderEvents.Ready, handler1);
-			provider.events.addHandler(ProviderEvents.Ready, handler2);
+			OpenFeature.addHandler(ProviderEvents.Ready, handler1);
+			OpenFeature.addHandler(ProviderEvents.Ready, handler2);
 
 			await OpenFeature.setProviderAndWait(provider);
 
@@ -157,18 +83,12 @@ describe('Provider Events', () => {
 
 		it('should allow removing event handlers', async () => {
 			const handler = vi.fn();
-
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
 			const provider = new FlagshipServerProvider({
 				endpoint: 'https://api.example.com/evaluate',
 			});
 
-			provider.events.addHandler(ProviderEvents.Ready, handler);
-			provider.events.removeHandler(ProviderEvents.Ready, handler);
+			OpenFeature.addHandler(ProviderEvents.Ready, handler);
+			OpenFeature.removeHandler(ProviderEvents.Ready, handler);
 
 			await OpenFeature.setProviderAndWait(provider);
 

--- a/sdks/typescript/tests/server-provider.test.ts
+++ b/sdks/typescript/tests/server-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Logger } from '@openfeature/server-sdk';
-import { ErrorCode } from '@openfeature/server-sdk';
+import { ErrorCode, OpenFeature, ProviderEvents } from '@openfeature/server-sdk';
 import { FlagshipServerProvider } from '../src/server-provider.js';
 
 // Mock fetch globally
@@ -17,6 +17,8 @@ const noopLogger: Logger = {
 describe('FlagshipServerProvider', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		OpenFeature.clearHandlers();
+		OpenFeature.clearProviders();
 	});
 
 	describe('constructor', () => {
@@ -727,56 +729,18 @@ describe('FlagshipServerProvider', () => {
 	});
 
 	describe('lifecycle', () => {
-		it('status is NOT_READY before initialize', () => {
-			const { ProviderStatus } = require('@openfeature/server-sdk');
+		it('setProviderAndWait does not request the endpoint', async () => {
 			const provider = new FlagshipServerProvider({ endpoint: 'https://api.example.com/evaluate' });
-			expect(provider.status).toBe(ProviderStatus.NOT_READY);
+			await OpenFeature.setProviderAndWait(provider);
+			expect(global.fetch).not.toHaveBeenCalled();
 		});
 
-		it('status is READY after successful initialize', async () => {
-			const { ProviderStatus } = require('@openfeature/server-sdk');
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
+		it('setProviderAndWait emits READY', async () => {
+			const readyHandler = vi.fn();
+			OpenFeature.addHandler(ProviderEvents.Ready, readyHandler);
 			const provider = new FlagshipServerProvider({ endpoint: 'https://api.example.com/evaluate' });
-			await provider.initialize();
-			expect(provider.status).toBe(ProviderStatus.READY);
-		});
-
-		it('status is READY after initialize when health check returns 404', async () => {
-			const { ProviderStatus } = require('@openfeature/server-sdk');
-			const mockResponse = new Response(null, { status: 404, statusText: 'Not Found' });
-			(global.fetch as any).mockResolvedValueOnce(mockResponse);
-
-			const provider = new FlagshipServerProvider({ endpoint: 'https://api.example.com/evaluate', retries: 0 });
-			await provider.initialize();
-			expect(provider.status).toBe(ProviderStatus.READY);
-		});
-
-		it('status is ERROR after initialize when endpoint unreachable', async () => {
-			const { ProviderStatus } = require('@openfeature/server-sdk');
-			(global.fetch as any).mockRejectedValueOnce(new Error('network down'));
-
-			const provider = new FlagshipServerProvider({ endpoint: 'https://api.example.com/evaluate', retries: 0 });
-			await provider.initialize();
-			expect(provider.status).toBe(ProviderStatus.ERROR);
-		});
-
-		it('status resets to NOT_READY after onClose', async () => {
-			const { ProviderStatus } = require('@openfeature/server-sdk');
-			(global.fetch as any).mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({ flagKey: '_flagship_health_check', value: true }),
-			});
-
-			const provider = new FlagshipServerProvider({ endpoint: 'https://api.example.com/evaluate' });
-			await provider.initialize();
-			expect(provider.status).toBe(ProviderStatus.READY);
-
-			await provider.onClose();
-			expect(provider.status).toBe(ProviderStatus.NOT_READY);
+			await OpenFeature.setProviderAndWait(provider);
+			expect(readyHandler).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
- Previously, both SDK server providers fired a sentinel flag evaluation (`_flagship_health_check`) on `initialize()` to probe endpoint reachability
- Removed this extra network request — flag evaluation happens only when resolving real flags
- Removed internal `status`/`currentStatus` field and getter from both providers — the OpenFeature SDK owns provider state (JS SDK marks provider `status` as deprecated; Python registry tracks it in `ProviderRegistry._provider_status`)
- Removed `initialize()` and `onClose()` from the TS server provider; Python provider inherits the no-op `initialize()` from `AbstractProvider`
- Kept Python `shutdown()` / `shutdown_async()` for HTTP client cleanup
- Updated tests to assert readiness via `OpenFeature.setProviderAndWait()` / `api.set_provider()` instead of calling `provider.initialize()` directly
- Updated docs to reflect no-I/O initialization and SDK-managed shutdown